### PR TITLE
Manager: Schedules & Webhooks

### DIFF
--- a/manager/README.md
+++ b/manager/README.md
@@ -18,6 +18,14 @@ method|path
 `DELETE`|`/checklists/<id>`
 `POST`|`/checklists/<id>/run`
 `POST`|`/checklists/<id>/snapshots`
+`GET`|`/schedules`
+`POST`|`/schedules`
+`PUT`|`/schedules/<id>`
+`DELETE`|`/schedules/<id>`
+`GET`|`/webhooks`
+`POST`|`/webhooks`
+`PUT`|`/webhooks/<id>`
+`DELETE`|`/webhooks/<id>`
 
 ### Deploying
 

--- a/manager/package-lock.json
+++ b/manager/package-lock.json
@@ -35,6 +35,12 @@
       "integrity": "sha512-EIjmpvnHj+T4nMcKwHwxZKUfDmphIKJc2qnEMhSoOvr1lYEQpuRKRz8orWr//krYIIArS/KGGLfL2YGVUYXmIA==",
       "dev": true
     },
+    "@types/cron": {
+      "version": "1.3.0",
+      "resolved": "http://registry.npmjs.org/@types/cron/-/cron-1.3.0.tgz",
+      "integrity": "sha512-RNJ6Hbxs9CbUw+Bxt8kpN8/yNlYG1xli0JZSO1xTJJxFjgD2KWctFSkJeJpjf9iLJU0jeNPoJ5LEru7eBN3xuA==",
+      "dev": true
+    },
     "@types/events": {
       "version": "1.2.0",
       "resolved": "http://registry.npmjs.org/@types/events/-/events-1.2.0.tgz",
@@ -667,6 +673,14 @@
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
       "requires": {
         "capture-stack-trace": "^1.0.0"
+      }
+    },
+    "cron": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.5.0.tgz",
+      "integrity": "sha512-j7zMFLrcSta53xqOvETUt8ge+PM14GtF47gEGJJeVlM6qP24/eWHSgtiWiEiKBR2sHS8xZaBQZq4D7vFXg8dcQ==",
+      "requires": {
+        "moment-timezone": "^0.5.x"
       }
     },
     "crypto-random-string": {
@@ -2142,8 +2156,15 @@
     "moment": {
       "version": "2.22.2",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
-      "dev": true
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
+    },
+    "moment-timezone": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
+      "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "ms": {
       "version": "2.0.0",

--- a/manager/package.json
+++ b/manager/package.json
@@ -18,6 +18,7 @@
   "author": "Dillon Forrest",
   "license": "GPL-3.0",
   "devDependencies": {
+    "@types/cron": "1.3.0",
     "@types/express": "4.16.0",
     "@types/mocha": "5.2.5",
     "@types/node": "10.12.0",
@@ -31,6 +32,7 @@
   },
   "dependencies": {
     "body-parser": "1.18.3",
+    "cron": "1.5.0",
     "express": "4.16.4",
     "nodemon": "1.18.4",
     "pg": "7.5.0",

--- a/manager/scripts/setupDatabase.js
+++ b/manager/scripts/setupDatabase.js
@@ -34,7 +34,9 @@ async function setupDatabase() {
   await client.query(`create table schedules (
     id serial primary key,
     checklist_id integer references checklists (id),
-    cron text not null
+    cron text not null,
+    last_ran_at timestamptz not null,
+    next_run_at timestamptz
   )`);
 
   await client.query(`create table webhooks (

--- a/manager/scripts/setupDatabase.js
+++ b/manager/scripts/setupDatabase.js
@@ -30,7 +30,20 @@ async function setupDatabase() {
     value text not null,
     unique (flow_id, name)
   )`);
-  console.log("Database tables api_keys, checklists, flows and snapshots created.");
+
+  await client.query(`create table schedules (
+    id serial primary key,
+    checklist_id integer references checklists (id),
+    cron text not null
+  )`);
+
+  await client.query(`create table webhooks (
+    id serial primary key,
+    api_key_id integer references api_keys (id),
+    event_type text not null,
+    url text not null
+  )`);
+  console.log("Database tables api_keys, checklists, flows, snapshots, schedules and webhooks created.");
   client.end();
 }
 setupDatabase().catch((err) => {

--- a/manager/src/app.spec.ts
+++ b/manager/src/app.spec.ts
@@ -128,7 +128,7 @@ describe("Checklists", () => {
       .expect("Content-Type", /json/)
       .expect(201);
     const checklists = await app.checklistService.findAll(apiKey.id);
-    assert.deepEqual(response.body, { data: { checklist: checklists[0] } });
+    assert.deepEqual(response.body, { data: { checklist: checklists[0].toJSON() } });
   });
 
   it("Create (POST /v1/checklists) - Bad Request", async () => {
@@ -153,7 +153,7 @@ describe("Checklists", () => {
       .send({ workerOrigin: checklist.workerOrigin })
       .expect("Content-Type", /json/)
       .expect(200);
-    assert.deepEqual(response.body, { data: { checklist } });
+    assert.deepEqual(response.body, { data: { checklist: checklist.toJSON() } });
   });
 
   it("Update (PUT /v1/checklists/<id>) - Bad Request", async () => {
@@ -414,7 +414,8 @@ describe("Schedules", () => {
 
   it("List (GET /v1/schedules) - Multiple items", async () => {
     const result = await app.database.query(
-      `insert into schedules (checklist_id, cron) values ($1, '0 */15 * * * *'), ($1, '0 * 1 * * *') returning *`,
+      `insert into schedules (checklist_id, cron, last_ran_at)
+        values ($1, '0 */15 * * * *', now()), ($1, '0 * 1 * * *', now()) returning *`,
       [checklistId],
     );
     const schedules = result.rows.map((r: { id: number; cron: string }) => ({
@@ -441,7 +442,7 @@ describe("Schedules", () => {
       .expect("Content-Type", /json/)
       .expect(201);
     const schedules = await app.scheduleService.findAll(apiKey.id);
-    assert.deepEqual(response.body, { data: { schedule: schedules[0] } });
+    assert.deepEqual(response.body, { data: { schedule: schedules[0].toJSON() } });
   });
 
   it("Create (POST /v1/schedules) - Bad Request", async () => {
@@ -477,7 +478,7 @@ describe("Schedules", () => {
       .send({ cron: schedule.cron })
       .expect("Content-Type", /json/)
       .expect(200);
-    assert.deepEqual(response.body, { data: { schedule } });
+    assert.deepEqual(response.body, { data: { schedule: schedule.toJSON() } });
   });
 
   it("Update (PUT /v1/schedules/<id>) - Bad Request", async () => {

--- a/manager/src/app.spec.ts
+++ b/manager/src/app.spec.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert";
 import * as supertest from "supertest";
-import app, { ApiKey, Application } from "./app";
+import app, { Application } from "./app";
+import { ApiKey } from "./entities";
 
 // tslint:disable:max-line-length
 

--- a/manager/src/app.spec.ts
+++ b/manager/src/app.spec.ts
@@ -13,7 +13,7 @@ function authorizationHeaderForKey(key: string) {
 
 before(async () => {
   await app.setup();
-  await app.database.query(`truncate api_keys, checklists, flows, snapshots`);
+  await app.database.query(`truncate api_keys, checklists, flows, snapshots, schedules, webhooks`);
 });
 
 describe("App", () => {
@@ -382,5 +382,150 @@ describe("Snapshots", () => {
 
     const snapshots = await app.snapshotService.findAllByFlow(flow.id);
     assert.deepEqual(snapshots.map((s) => s.value), ["!", "@"]);
+  });
+});
+
+describe("Schedules", () => {
+  let apiKey: ApiKey = null;
+  let checklistId: number = null;
+
+  before(async () => {
+    apiKey = await app.apiKeyService.create();
+    const result = await app.database.query(
+      `insert into checklists (api_key_id, worker_origin) values ($1, 'http://1') returning *`,
+      [apiKey.id],
+    );
+    checklistId = result.rows[0].id;
+  });
+
+  beforeEach(async () => {
+    await app.database.query(`truncate schedules`);
+  });
+
+  it("List (GET /v1/schedules) - No item", async () => {
+    const response = await supertest(app.httpServer)
+      .get("/v1/schedules")
+      .set("Authorization", authorizationHeaderForKey(apiKey.key))
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(200);
+    assert.deepEqual(response.body, { data: { schedules: [] } });
+  });
+
+  it("List (GET /v1/schedules) - Multiple items", async () => {
+    const result = await app.database.query(
+      `insert into schedules (checklist_id, cron) values ($1, '0 */15 * * * *'), ($1, '0 * 1 * * *') returning *`,
+      [checklistId],
+    );
+    const schedules = result.rows.map((r: { id: number; cron: string }) => ({
+      checklistId,
+      cron: r.cron,
+      id: r.id,
+    }));
+
+    const response = await supertest(app.httpServer)
+      .get("/v1/schedules")
+      .set("Authorization", authorizationHeaderForKey(apiKey.key))
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(200);
+    assert.deepEqual(response.body, { data: { schedules } });
+  });
+
+  it("Create (POST /v1/schedules)", async () => {
+    const response = await supertest(app.httpServer)
+      .post("/v1/schedules")
+      .set("Authorization", authorizationHeaderForKey(apiKey.key))
+      .set("Accept", "application/json")
+      .send({ checklistId, cron: "* * * * * *" })
+      .expect("Content-Type", /json/)
+      .expect(201);
+    const schedules = await app.scheduleService.findAll(apiKey.id);
+    assert.deepEqual(response.body, { data: { schedule: schedules[0] } });
+  });
+
+  it("Create (POST /v1/schedules) - Bad Request", async () => {
+    const response = await supertest(app.httpServer)
+      .post("/v1/schedules")
+      .set("Authorization", authorizationHeaderForKey(apiKey.key))
+      .set("Accept", "application/json")
+      .send({ cron: 0 })
+      .expect("Content-Type", /json/)
+      .expect(400);
+    assert.deepEqual(response.body.error, Application.Errors.BadRequest);
+  });
+
+  it("Create (POST /v1/schedules) - Not our checklist", async () => {
+    const response = await supertest(app.httpServer)
+      .post("/v1/schedules")
+      .set("Authorization", authorizationHeaderForKey(apiKey.key))
+      .set("Accept", "application/json")
+      .send({ checklistId: 0, cron: "* * * * * *" })
+      .expect("Content-Type", /json/)
+      .expect(404);
+    assert.deepEqual(response.body.error, Application.Errors.NotFound);
+  });
+
+  it("Update (PUT /v1/schedules/<id>)", async () => {
+    const schedule = await app.scheduleService.create(checklistId, "0 30 * * * *");
+    schedule.cron = "0 0 * * * *";
+
+    const response = await supertest(app.httpServer)
+      .put("/v1/schedules/" + String(schedule.id))
+      .set("Authorization", authorizationHeaderForKey(apiKey.key))
+      .set("Accept", "application/json")
+      .send({ cron: schedule.cron })
+      .expect("Content-Type", /json/)
+      .expect(200);
+    assert.deepEqual(response.body, { data: { schedule } });
+  });
+
+  it("Update (PUT /v1/schedules/<id>) - Bad Request", async () => {
+    const schedule = await app.scheduleService.create(checklistId, "* * * * * *");
+
+    const response = await supertest(app.httpServer)
+      .put("/v1/schedules/" + String(schedule.id))
+      .set("Authorization", authorizationHeaderForKey(apiKey.key))
+      .set("Accept", "application/json")
+      .send({ cron: 0 })
+      .expect("Content-Type", /json/)
+      .expect(400);
+    assert.deepEqual(response.body.error, Application.Errors.BadRequest);
+  });
+
+  it("Update (PUT /v1/schedules/<id>) - Not Found", async () => {
+    const response = await supertest(app.httpServer)
+      .put("/v1/schedules/1")
+      .set("Authorization", authorizationHeaderForKey(apiKey.key))
+      .set("Accept", "application/json")
+      .send({ cron: "* * * * * *" })
+      .expect("Content-Type", /json/)
+      .expect(404);
+    assert.deepEqual(response.body.error, Application.Errors.NotFound);
+  });
+
+  it("Delete (DELETE /v1/schedules/<id>)", async () => {
+    const schedule = await app.scheduleService.create(checklistId, "* * * * * *");
+
+    const response = await supertest(app.httpServer)
+      .delete("/v1/schedules/" + String(schedule.id))
+      .set("Authorization", authorizationHeaderForKey(apiKey.key))
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(200);
+    assert.deepEqual(response.body, { message: "Successfully deleted." });
+
+    const schedules = await app.scheduleService.findAll(apiKey.id);
+    assert(schedules.length === 0);
+  });
+
+  it.only("Delete (DELETE /v1/schedules/<id>) - Not Found", async () => {
+    const response = await supertest(app.httpServer)
+      .delete("/v1/schedules/1")
+      .set("Authorization", authorizationHeaderForKey(apiKey.key))
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(404);
+    assert.deepEqual(response.body.error, Application.Errors.NotFound);
   });
 });

--- a/manager/src/app.ts
+++ b/manager/src/app.ts
@@ -1,10 +1,28 @@
 import * as Ajv from "ajv";
 import * as bodyParser from "body-parser";
-import * as crypto from "crypto";
 import * as express from "express";
 import * as pg from "pg";
-import * as request from "request-promise-native";
+
+import {
+  ApiKey,
+  Assertion,
+  Checklist,
+  Flow,
+  IFlowRunSummary,
+  Schedule,
+  Snapshot,
+  Webhook,
+  WebhookEventType,
+} from "./entities";
 import { V1SnapshotsUpdatePayload } from "./schemas";
+import {
+  ApiKeyService,
+  ChecklistService,
+  FlowService,
+  ScheduleService,
+  SnapshotService,
+  WebhookService,
+} from "./services";
 
 declare global {
   namespace Express {
@@ -43,12 +61,16 @@ export class Application {
   public checklistService: ChecklistService;
   public flowService: FlowService;
   public snapshotService: SnapshotService;
+  public scheduleService: ScheduleService;
+  public webhookService: WebhookService;
 
   constructor() {
     this.apiKeyService = new ApiKeyService(this);
     this.checklistService = new ChecklistService(this);
     this.flowService = new FlowService(this);
     this.snapshotService = new SnapshotService(this);
+    this.scheduleService = new ScheduleService(this);
+    this.webhookService = new WebhookService(this);
   }
 
   public setupConfig() {
@@ -73,12 +95,18 @@ export class Application {
 
     const authenticate = middlewareRequireApiKey.bind(null, this);
     r.delete("/api-keys", authenticate, handleApiKeysDelete.bind(null, this));
+
     r.get("/v1/checklists", authenticate, handleChecklistsList.bind(null, this));
     r.post("/v1/checklists", authenticate, handleChecklistsCreate.bind(null, this));
     r.put("/v1/checklists/:id", authenticate, handleChecklistsUpdate.bind(null, this));
     r.delete("/v1/checklists/:id", authenticate, handleChecklistsDelete.bind(null, this));
     r.post("/v1/checklists/:id/run", authenticate, handleChecklistsRun.bind(null, this));
     r.post("/v1/checklists/:id/snapshots", authenticate, handleSnapshotsUpdate.bind(null, this));
+
+    r.get("/v1/checklists", authenticate, handleChecklistsList.bind(null, this));
+    r.post("/v1/checklists", authenticate, handleChecklistsCreate.bind(null, this));
+    r.put("/v1/checklists/:id", authenticate, handleChecklistsUpdate.bind(null, this));
+    r.delete("/v1/checklists/:id", authenticate, handleChecklistsDelete.bind(null, this));
 
     r.use(handleNotFound.bind(null, this));
   }
@@ -107,299 +135,6 @@ export class Application {
       // tslint:disable-next-line:no-console
       console.log(`server is listening on ${port}`);
     });
-  }
-}
-
-export class ApiKey {
-  public id: number;
-  public key: string;
-
-  constructor(id: number, key: string) {
-    this.id = id;
-    this.key = key;
-  }
-}
-
-export class Checklist {
-  public id: number;
-  public apiKeyId: number;
-  public workerOrigin: string;
-
-  constructor(id: number, workerOrigin: string) {
-    this.id = id;
-    this.workerOrigin = workerOrigin;
-  }
-}
-
-interface IFlowRunSummary {
-  match: number;
-  miss: number;
-  new: number;
-}
-
-export class Flow {
-  public id: number;
-  public name: string;
-  public assertions: Assertion[];
-  public summary: IFlowRunSummary;
-
-  constructor(id: number, name: string) {
-    this.id = id;
-    this.name = name;
-    this.assertions = [];
-    this.summary = { match: 0, miss: 0, new: 0 } as IFlowRunSummary;
-  }
-}
-
-export class Assertion {
-  public id: number;
-  public name: string;
-  public snapshot: string;
-  public expectedSnapshot: string;
-  public result: string;
-
-  constructor(id: number, name: string, snapshot: string, expectedSnapshot: string, result: string) {
-    this.id = id;
-    this.name = name;
-    this.snapshot = snapshot;
-    this.expectedSnapshot = expectedSnapshot;
-    this.result = result;
-  }
-
-  // Stips the `[2]` from the end of the snapshot name (like `1 + 1 is equal to 2 [2]`
-  public nameWithoutNumber() {
-    const parts = this.name.split("[");
-    if (parts.length > 1) {
-      return parts.slice(0, -1).join("[");
-    }
-    return this.name;
-  }
-}
-
-export class Snapshot {
-  public id: number;
-  public name: string;
-  public value: string;
-
-  constructor(id: number, name: string, value: string) {
-    this.id = id;
-    this.name = name;
-    this.value = value;
-  }
-
-  public toAssertion(): Assertion {
-    return new Assertion(this.id, this.name, this.value, "", "");
-  }
-}
-
-class ApiKeyService {
-  public app: Application;
-
-  constructor(app: Application) {
-    this.app = app;
-  }
-
-  public entityFromRow(row: { id: number; key: string }): ApiKey {
-    return new ApiKey(row.id, row.key);
-  }
-
-  public async create() {
-    const time = new Date().getTime().toString();
-    const key = crypto
-      .createHash("md5")
-      .update(time)
-      .digest("hex");
-    const result = await this.app.database.query(`insert into api_keys (key) values ($1) returning *`, [key]);
-    return this.entityFromRow(result.rows[0]);
-  }
-
-  public async delete(id: number) {
-    await this.app.database.query(`delete from api_keys where id = $1`, [id]);
-  }
-
-  public async findByKey(key: string): Promise<ApiKey> {
-    const result = await this.app.database.query(`select * from api_keys where key = $1`, [key]);
-    if (result.rows.length === 0) {
-      return null;
-    }
-    return this.entityFromRow(result.rows[0]);
-  }
-}
-
-class ChecklistService {
-  public app: Application;
-
-  constructor(app: Application) {
-    this.app = app;
-  }
-
-  public entityFromRow(row: { id: number; worker_origin: string }): Checklist {
-    return new Checklist(row.id, row.worker_origin);
-  }
-
-  public async create(apiKeyId: number, workerOrigin: string): Promise<Checklist> {
-    const result = await this.app.database.query(
-      `insert into checklists (api_key_id, worker_origin) values ($1, $2) returning *`,
-      [apiKeyId, workerOrigin],
-    );
-    return this.entityFromRow(result.rows[0]);
-  }
-
-  public async update(checklist: Checklist) {
-    await this.app.database.query(`update checklists set worker_origin = $2 where id = $1`, [
-      checklist.id,
-      checklist.workerOrigin,
-    ]);
-  }
-
-  public async delete(id: number) {
-    await this.app.database.query(`delete from snapshots where flow_id in
-      (select id from flows where checklist_id = $1)`, [id]);
-    await this.app.database.query(`delete from flows where checklist_id = $1`, [id]);
-    await this.app.database.query(`delete from checklists where id = $1`, [id]);
-  }
-
-  public async deleteByApiKeyId(id: number) {
-    await this.app.database.query(`delete from snapshots where flow_id in
-      (select id from flows where checklist_id in
-        (select id from checklists where api_key_id = $1))`, [id]);
-    await this.app.database.query(`delete from flows where checklist_id in
-      (select id from checklists where api_key_id = $1)`, [id]);
-    await this.app.database.query(`delete from checklists where api_key_id = $1`, [id]);
-  }
-
-  public async find(id: number, apiKeyId: number): Promise<Checklist> {
-    const result = await this.app.database.query(`select * from checklists where id = $1 and api_key_id = $2`, [
-      id,
-      apiKeyId,
-    ]);
-    if (result.rows.length === 0) {
-      return null;
-    }
-    return this.entityFromRow(result.rows[0]);
-  }
-
-  public async findAll(apiKeyId: number): Promise<Checklist[]> {
-    const query = `select * from checklists where api_key_id = $1 order by id`;
-    const result = await this.app.database.query(query, [apiKeyId]);
-    return result.rows.map(this.entityFromRow);
-  }
-
-  public async run(checklist: Checklist): Promise<Flow[]> {
-    const flows = await this.app.flowService.findAllByChecklist(checklist.id);
-    for (const flow of flows) {
-      const snapshots = await this.app.snapshotService.findAllByFlow(flow.id);
-      flow.assertions = snapshots.map((s) => s.toAssertion());
-    }
-    const result = await request.post({
-      body: {
-        flows: flows.map((f) => ({
-          assertions: f.assertions.map((a) => ({
-            name: a.nameWithoutNumber(),
-            snapshot: a.snapshot,
-          })),
-          name: f.name,
-        })),
-      },
-      json: true,
-      uri: checklist.workerOrigin + "/v0/run",
-    });
-
-    for (const flow of result.flows) {
-      flow.summary = { match: 0, miss: 0, new: 0 } as IFlowRunSummary;
-
-      let databaseFlow = flows.find((f) => f.name === flow.name);
-      if (!databaseFlow) {
-        databaseFlow = await this.app.flowService.create(checklist.id, flow.name);
-      }
-
-      const assertionsSeen = new Map<string, number>();
-      for (const assertion of flow.assertions) {
-        // Compute assertion name (accounting for duplicates)
-        let assertionName = assertion.name;
-        if (assertionsSeen.get(assertion.name) > 0) {
-          assertionName += "[" + String(assertionsSeen.get(assertion.name) + 1) + "]";
-        }
-        assertionsSeen.set(assertion.Name, assertionsSeen.get(assertion.Name) + 1);
-
-        // Create missing / new snapshots
-        let databaseAssertion = databaseFlow.assertions.find((a) => a.name === assertionName);
-        if (!databaseAssertion) {
-          const snapshot = await this.app.snapshotService.create(
-            databaseFlow.id, assertionName, assertion.snapshot,
-          );
-          databaseAssertion = snapshot.toAssertion();
-        }
-
-        // Augment worker response with saved snapshot data & summary
-        assertion.name = assertionName;
-        if (assertion.result === "MISS") {
-          assertion.expectedSnapshot = databaseAssertion.snapshot;
-        }
-        flow.summary[assertion.result.toLowerCase()]++;
-      }
-    }
-
-    return result.flows as Flow[];
-  }
-}
-
-class FlowService {
-  public app: Application;
-
-  constructor(app: Application) {
-    this.app = app;
-  }
-
-  public entityFromRow(row: { id: number; name: string }): Flow {
-    return new Flow(row.id, row.name);
-  }
-
-  public async create(checklistId: number, name: string): Promise<Flow> {
-    const result = await this.app.database.query(
-      `insert into flows (checklist_id, name) values ($1, $2) returning *`,
-      [checklistId, name],
-    );
-    return this.entityFromRow(result.rows[0]);
-  }
-
-  public async findAllByChecklist(checklistId: number): Promise<Flow[]> {
-    const query = `select * from flows where checklist_id = $1 order by id`;
-    const result = await this.app.database.query(query, [checklistId]);
-    return result.rows.map(this.entityFromRow);
-  }
-}
-
-class SnapshotService {
-  public app: Application;
-
-  constructor(app: Application) {
-    this.app = app;
-  }
-
-  public entityFromRow(row: { id: number; name: string, value: string }): Snapshot {
-    return new Snapshot(row.id, row.name, row.value);
-  }
-
-  public async create(flowId: number, name: string, value: string): Promise<Snapshot> {
-    const result = await this.app.database.query(
-      `insert into snapshots (flow_id, name, value) values ($1, $2, $3) returning *`,
-      [flowId, name, value],
-    );
-    return this.entityFromRow(result.rows[0]);
-  }
-
-  public async update(checklistId: number, flowName: string, name: string, value: string): Promise<void> {
-    const query = `insert into snapshots (flow_id, name, value)
-      values ((select id from flows where checklist_id = $1 and name = $2), $3, $4)
-      on conflict (flow_id, name) do nothing`;
-    await this.app.database.query(query, [checklistId, flowName, name, value]);
-  }
-
-  public async findAllByFlow(flowId: number): Promise<Snapshot[]> {
-    const query = `select * from snapshots where flow_id = $1 order by id`;
-    const result = await this.app.database.query(query, [flowId]);
-    return result.rows.map(this.entityFromRow);
   }
 }
 

--- a/manager/src/entities.ts
+++ b/manager/src/entities.ts
@@ -96,6 +96,10 @@ export enum WebhookEventType {
   ScheduledChecklistStart = "SCHEDULED_CHECKLIST_START",
   ScheduledChecklistEnd = "SCHEDULED_CHECKLIST_END",
 }
+export const WebhookEventTypes = [
+  WebhookEventType.ScheduledChecklistStart,
+  WebhookEventType.ScheduledChecklistEnd,
+];
 
 export class Webhook {
   public id: number;

--- a/manager/src/entities.ts
+++ b/manager/src/entities.ts
@@ -13,9 +13,17 @@ export class Checklist {
   public apiKeyId: number;
   public workerOrigin: string;
 
-  constructor(id: number, workerOrigin: string) {
+  constructor(id: number, workerOrigin: string, apiKeyId?: number) {
     this.id = id;
     this.workerOrigin = workerOrigin;
+    this.apiKeyId = apiKeyId;
+  }
+
+  public toJSON() {
+    return {
+      id: this.id,
+      workerOrigin: this.workerOrigin,
+    };
   }
 }
 
@@ -84,11 +92,23 @@ export class Schedule {
   public id: number;
   public checklistId: number;
   public cron: string;
+  public lastRanAt: Date;
+  public nextRunAt: Date;
 
-  constructor(id: number, checklistId: number, cron: string) {
+  constructor(id: number, checklistId: number, cron: string, lastRanAt: Date, nextRunAt: Date) {
     this.id = id;
     this.checklistId = checklistId;
     this.cron = cron;
+    this.lastRanAt = lastRanAt;
+    this.nextRunAt = nextRunAt;
+  }
+
+  public toJSON() {
+    return {
+      checklistId: this.checklistId,
+      cron: this.cron,
+      id: this.id,
+    };
   }
 }
 

--- a/manager/src/entities.ts
+++ b/manager/src/entities.ts
@@ -1,0 +1,110 @@
+export class ApiKey {
+  public id: number;
+  public key: string;
+
+  constructor(id: number, key: string) {
+    this.id = id;
+    this.key = key;
+  }
+}
+
+export class Checklist {
+  public id: number;
+  public apiKeyId: number;
+  public workerOrigin: string;
+
+  constructor(id: number, workerOrigin: string) {
+    this.id = id;
+    this.workerOrigin = workerOrigin;
+  }
+}
+
+export interface IFlowRunSummary {
+  match: number;
+  miss: number;
+  new: number;
+}
+
+export class Flow {
+  public id: number;
+  public name: string;
+  public assertions: Assertion[];
+  public summary: IFlowRunSummary;
+
+  constructor(id: number, name: string) {
+    this.id = id;
+    this.name = name;
+    this.assertions = [];
+    this.summary = { match: 0, miss: 0, new: 0 } as IFlowRunSummary;
+  }
+}
+
+export class Assertion {
+  public id: number;
+  public name: string;
+  public snapshot: string;
+  public expectedSnapshot: string;
+  public result: string;
+
+  constructor(id: number, name: string, snapshot: string, expectedSnapshot: string, result: string) {
+    this.id = id;
+    this.name = name;
+    this.snapshot = snapshot;
+    this.expectedSnapshot = expectedSnapshot;
+    this.result = result;
+  }
+
+  // Stips the `[2]` from the end of the snapshot name (like `1 + 1 is equal to 2 [2]`
+  public nameWithoutNumber() {
+    const parts = this.name.split("[");
+    if (parts.length > 1) {
+      return parts.slice(0, -1).join("[");
+    }
+    return this.name;
+  }
+}
+
+export class Snapshot {
+  public id: number;
+  public name: string;
+  public value: string;
+
+  constructor(id: number, name: string, value: string) {
+    this.id = id;
+    this.name = name;
+    this.value = value;
+  }
+
+  public toAssertion(): Assertion {
+    return new Assertion(this.id, this.name, this.value, "", "");
+  }
+}
+
+export class Schedule {
+  public id: number;
+  public checklistId: number;
+  public cron: string;
+
+  constructor(id: number, checklistId: number, cron: string) {
+    this.id = id;
+    this.checklistId = checklistId;
+    this.cron = cron;
+  }
+}
+
+export enum WebhookEventType {
+  ScheduledChecklistStart = "SCHEDULED_CHECKLIST_START",
+  ScheduledChecklistEnd = "SCHEDULED_CHECKLIST_END",
+}
+
+export class Webhook {
+  public id: number;
+  public eventType: WebhookEventType;
+  public url: string;
+
+  constructor(id: number, eventType: WebhookEventType, url: string) {
+    this.id = id;
+    this.eventType = eventType;
+    this.url = url;
+  }
+}

--- a/manager/src/services.ts
+++ b/manager/src/services.ts
@@ -1,0 +1,250 @@
+import * as crypto from "crypto";
+import * as request from "request-promise-native";
+
+import { Application } from "./app";
+import {
+  ApiKey,
+  Assertion,
+  Checklist,
+  Flow,
+  IFlowRunSummary,
+  Schedule,
+  Snapshot,
+  Webhook,
+  WebhookEventType,
+} from "./entities";
+
+export class ApiKeyService {
+  public app: Application;
+
+  constructor(app: Application) {
+    this.app = app;
+  }
+
+  public entityFromRow(row: { id: number; key: string }): ApiKey {
+    return new ApiKey(row.id, row.key);
+  }
+
+  public async create() {
+    const time = new Date().getTime().toString();
+    const key = crypto
+      .createHash("md5")
+      .update(time)
+      .digest("hex");
+    const result = await this.app.database.query(`insert into api_keys (key) values ($1) returning *`, [key]);
+    return this.entityFromRow(result.rows[0]);
+  }
+
+  public async delete(id: number) {
+    await this.app.database.query(`delete from api_keys where id = $1`, [id]);
+  }
+
+  public async findByKey(key: string): Promise<ApiKey> {
+    const result = await this.app.database.query(`select * from api_keys where key = $1`, [key]);
+    if (result.rows.length === 0) {
+      return null;
+    }
+    return this.entityFromRow(result.rows[0]);
+  }
+}
+
+export class ChecklistService {
+  public app: Application;
+
+  constructor(app: Application) {
+    this.app = app;
+  }
+
+  public entityFromRow(row: { id: number; worker_origin: string }): Checklist {
+    return new Checklist(row.id, row.worker_origin);
+  }
+
+  public async create(apiKeyId: number, workerOrigin: string): Promise<Checklist> {
+    const result = await this.app.database.query(
+      `insert into checklists (api_key_id, worker_origin) values ($1, $2) returning *`,
+      [apiKeyId, workerOrigin],
+    );
+    return this.entityFromRow(result.rows[0]);
+  }
+
+  public async update(checklist: Checklist) {
+    await this.app.database.query(`update checklists set worker_origin = $2 where id = $1`, [
+      checklist.id,
+      checklist.workerOrigin,
+    ]);
+  }
+
+  public async delete(id: number) {
+    await this.app.database.query(`delete from snapshots where flow_id in
+      (select id from flows where checklist_id = $1)`, [id]);
+    await this.app.database.query(`delete from flows where checklist_id = $1`, [id]);
+    await this.app.database.query(`delete from checklists where id = $1`, [id]);
+  }
+
+  public async deleteByApiKeyId(id: number) {
+    await this.app.database.query(`delete from snapshots where flow_id in
+      (select id from flows where checklist_id in
+        (select id from checklists where api_key_id = $1))`, [id]);
+    await this.app.database.query(`delete from flows where checklist_id in
+      (select id from checklists where api_key_id = $1)`, [id]);
+    await this.app.database.query(`delete from checklists where api_key_id = $1`, [id]);
+  }
+
+  public async find(id: number, apiKeyId: number): Promise<Checklist> {
+    const result = await this.app.database.query(`select * from checklists where id = $1 and api_key_id = $2`, [
+      id,
+      apiKeyId,
+    ]);
+    if (result.rows.length === 0) {
+      return null;
+    }
+    return this.entityFromRow(result.rows[0]);
+  }
+
+  public async findAll(apiKeyId: number): Promise<Checklist[]> {
+    const query = `select * from checklists where api_key_id = $1 order by id`;
+    const result = await this.app.database.query(query, [apiKeyId]);
+    return result.rows.map(this.entityFromRow);
+  }
+
+  public async run(checklist: Checklist): Promise<Flow[]> {
+    const flows = await this.app.flowService.findAllByChecklist(checklist.id);
+    for (const flow of flows) {
+      const snapshots = await this.app.snapshotService.findAllByFlow(flow.id);
+      flow.assertions = snapshots.map((s) => s.toAssertion());
+    }
+    const result = await request.post({
+      body: {
+        flows: flows.map((f) => ({
+          assertions: f.assertions.map((a) => ({
+            name: a.nameWithoutNumber(),
+            snapshot: a.snapshot,
+          })),
+          name: f.name,
+        })),
+      },
+      json: true,
+      uri: checklist.workerOrigin + "/v0/run",
+    });
+
+    for (const flow of result.flows) {
+      flow.summary = { match: 0, miss: 0, new: 0 } as IFlowRunSummary;
+
+      let databaseFlow = flows.find((f) => f.name === flow.name);
+      if (!databaseFlow) {
+        databaseFlow = await this.app.flowService.create(checklist.id, flow.name);
+      }
+
+      const assertionsSeen = new Map<string, number>();
+      for (const assertion of flow.assertions) {
+        // Compute assertion name (accounting for duplicates)
+        let assertionName = assertion.name;
+        if (assertionsSeen.get(assertion.name) > 0) {
+          assertionName += "[" + String(assertionsSeen.get(assertion.name) + 1) + "]";
+        }
+        assertionsSeen.set(assertion.Name, assertionsSeen.get(assertion.Name) + 1);
+
+        // Create missing / new snapshots
+        let databaseAssertion = databaseFlow.assertions.find((a) => a.name === assertionName);
+        if (!databaseAssertion) {
+          const snapshot = await this.app.snapshotService.create(
+            databaseFlow.id, assertionName, assertion.snapshot,
+          );
+          databaseAssertion = snapshot.toAssertion();
+        }
+
+        // Augment worker response with saved snapshot data & summary
+        assertion.name = assertionName;
+        if (assertion.result === "MISS") {
+          assertion.expectedSnapshot = databaseAssertion.snapshot;
+        }
+        flow.summary[assertion.result.toLowerCase()]++;
+      }
+    }
+
+    return result.flows as Flow[];
+  }
+}
+
+export class FlowService {
+  public app: Application;
+
+  constructor(app: Application) {
+    this.app = app;
+  }
+
+  public entityFromRow(row: { id: number; name: string }): Flow {
+    return new Flow(row.id, row.name);
+  }
+
+  public async create(checklistId: number, name: string): Promise<Flow> {
+    const result = await this.app.database.query(
+      `insert into flows (checklist_id, name) values ($1, $2) returning *`,
+      [checklistId, name],
+    );
+    return this.entityFromRow(result.rows[0]);
+  }
+
+  public async findAllByChecklist(checklistId: number): Promise<Flow[]> {
+    const query = `select * from flows where checklist_id = $1 order by id`;
+    const result = await this.app.database.query(query, [checklistId]);
+    return result.rows.map(this.entityFromRow);
+  }
+}
+
+export class SnapshotService {
+  public app: Application;
+
+  constructor(app: Application) {
+    this.app = app;
+  }
+
+  public entityFromRow(row: { id: number; name: string, value: string }): Snapshot {
+    return new Snapshot(row.id, row.name, row.value);
+  }
+
+  public async create(flowId: number, name: string, value: string): Promise<Snapshot> {
+    const result = await this.app.database.query(
+      `insert into snapshots (flow_id, name, value) values ($1, $2, $3) returning *`,
+      [flowId, name, value],
+    );
+    return this.entityFromRow(result.rows[0]);
+  }
+
+  public async update(checklistId: number, flowName: string, name: string, value: string): Promise<void> {
+    const query = `insert into snapshots (flow_id, name, value)
+      values ((select id from flows where checklist_id = $1 and name = $2), $3, $4)
+      on conflict (flow_id, name) do nothing`;
+    await this.app.database.query(query, [checklistId, flowName, name, value]);
+  }
+
+  public async findAllByFlow(flowId: number): Promise<Snapshot[]> {
+    const query = `select * from snapshots where flow_id = $1 order by id`;
+    const result = await this.app.database.query(query, [flowId]);
+    return result.rows.map(this.entityFromRow);
+  }
+}
+
+export class ScheduleService {
+  public app: Application;
+
+  constructor(app: Application) {
+    this.app = app;
+  }
+
+  public entityFromRow(row: { id: number; checklistId: number, cron: string }): Schedule {
+    return new Schedule(row.id, row.checklistId, row.cron);
+  }
+}
+
+export class WebhookService {
+  public app: Application;
+
+  constructor(app: Application) {
+    this.app = app;
+  }
+
+  public entityFromRow(row: { id: number; eventType: WebhookEventType, url: string }): Webhook {
+    return new Webhook(row.id, row.eventType, row.url);
+  }
+}

--- a/test-service/src/app.ts
+++ b/test-service/src/app.ts
@@ -70,6 +70,8 @@ export class Application {
     r.put("/todos/:id", authenticate, handleTodosUpdate.bind(null, this));
     r.delete("/todos/:id", authenticate, handleTodosDelete.bind(null, this));
 
+    r.post("/events", handleEvents.bind(null, this));
+
     r.use(handleNotFound.bind(null, this));
   }
 
@@ -317,6 +319,13 @@ async function handleTodosDelete(app: Application, req: express.Request, res: ex
   }
   await app.todoService.delete(todo.id);
   res.status(200).json({ message: "Successfully deleted." });
+}
+
+// Test endpoint for Webhooks. Simply logs request body to stdout.
+function handleEvents(app: Application, req: express.Request, res: express.Response) {
+  // tslint:disable-next-line:no-console
+  console.log(req.body);
+  res.status(200).json({});
 }
 
 function handleNotFound(app: Application, req: express.Request, res: express.Response) {


### PR DESCRIPTION
This PR adds 2 new entities: Schedules (tied to a checklist) and Webhooks (tied to an api key).

It also adds logic to run configured schedules on a regular basis (based on a user provided cron spec). "Running" a schedule entails running the associated checklist and sending out existing webhooks